### PR TITLE
Add pushJobSpec to ingestion yml files

### DIFF
--- a/batters-ingestion-spec.yml
+++ b/batters-ingestion-spec.yml
@@ -24,3 +24,8 @@ tableSpec:
   tableConfigURI: 'http://localhost:9000/tables/batters'
 pinotClusterSpecs:
   - controllerURI: 'http://localhost:9000'
+pushJobSpec:
+  pushParallelism: 2
+  pushAttempts: 2
+  pushRetryIntervalMillis: 1000
+  segmentUriPrefix: 'file://'

--- a/calcs-ingestion-spec.yml
+++ b/calcs-ingestion-spec.yml
@@ -24,3 +24,8 @@ tableSpec:
   tableConfigURI: 'http://localhost:9000/tables/calcs'
 pinotClusterSpecs:
   - controllerURI: 'http://localhost:9000'
+pushJobSpec:
+  pushParallelism: 2
+  pushAttempts: 2
+  pushRetryIntervalMillis: 1000
+  segmentUriPrefix: 'file://'

--- a/staples-ingestion-spec.yml
+++ b/staples-ingestion-spec.yml
@@ -19,8 +19,13 @@ recordReaderSpec:
     multiValueDelimiter: '—'
     header: Item_Count,Ship_Priority,Order_Priority,Order_Status,Order_Quantity,Sales_Total,Discount,Tax_Rate,Ship_Mode,Fill_Time,Gross_Profit,Price,Ship_Handle_Cost,Employee_Name,Employee_Dept,Manager_Name,Employee_Yrs_Exp,Employee_Salary,Customer_Name,Customer_State,Call_Center_Region,Customer_Balance,Customer_Segment,Prod_Type1,Prod_Type2,Prod_Type3,Prod_Type4,Product_Name,Product_Container,Ship_Promo,Supplier_Name,Supplier_Balance,Supplier_Region,Supplier_State,Order_ID,Order_Year,Order_Month,Order_Day,Order_Date,Order_Quarter,Product_Base_Margin,Product_ID,Receive_Time,Received_Date,Ship_Date,Ship_Charge,Total_Cycle_Time,Product_In_Stock,PID,Market_Segment
 tableSpec:
-  tableName: 'staples'
-  schemaURI: 'http://localhost:9000/tables/staples/schema'
-  tableConfigURI: 'http://localhost:9000/tables/staples'
+  tableName: 'Staples'
+  schemaURI: 'http://localhost:9000/tables/Staples/schema'
+  tableConfigURI: 'http://localhost:9000/tables/Staples'
 pinotClusterSpecs:
   - controllerURI: 'http://localhost:9000'
+pushJobSpec:
+  pushParallelism: 2
+  pushAttempts: 2
+  pushRetryIntervalMillis: 1000
+  segmentUriPrefix: 'file://'

--- a/staples-schema.json
+++ b/staples-schema.json
@@ -1,5 +1,5 @@
 {
-   "schemaName":"staples",
+   "schemaName":"Staples",
    "dimensionFieldSpecs":[
       {
          "name":"Item_Count",

--- a/staples-table-config.json
+++ b/staples-table-config.json
@@ -1,9 +1,9 @@
 {
-   "tableName":"staples",
+   "tableName":"Staples",
    "segmentsConfig":{
       "segmentAssignmentStrategy":"BalanceNumSegmentAssignmentStrategy",
       "segmentPushType":"APPEND",
-      "schemaName":"staples",
+      "schemaName":"Staples",
       "replication":1
    },
    "tableIndexConfig":{


### PR DESCRIPTION
Added pushJobSpec settings for ingestion yml files so they will work. Updated staples schema to create a 'Staples' table instead of 'staples' so the TDVT tests stop using a table alias (not supported by pinot).